### PR TITLE
Support raw JSON in FIREBASE_CREDENTIALS env var

### DIFF
--- a/src/main/java/com/teafactory/pureleaf/config/FirebaseConfig.java
+++ b/src/main/java/com/teafactory/pureleaf/config/FirebaseConfig.java
@@ -26,9 +26,16 @@ public class FirebaseConfig {
         try {
             InputStream serviceAccount;
             if (firebaseCredentials != null && !firebaseCredentials.isBlank()) {
-                // FIREBASE_CREDENTIALS holds the service account JSON, base64-encoded
-                byte[] decoded = Base64.getDecoder().decode(firebaseCredentials);
-                serviceAccount = new ByteArrayInputStream(decoded);
+                String trimmed = firebaseCredentials.trim();
+                byte[] jsonBytes;
+                if (trimmed.startsWith("{")) {
+                    // FIREBASE_CREDENTIALS holds the raw service account JSON
+                    jsonBytes = trimmed.getBytes(StandardCharsets.UTF_8);
+                } else {
+                    // FIREBASE_CREDENTIALS holds the service account JSON, base64-encoded
+                    jsonBytes = Base64.getDecoder().decode(trimmed);
+                }
+                serviceAccount = new ByteArrayInputStream(jsonBytes);
             } else {
                 // Local dev fallback: raw JSON file on disk (not present in deployed containers)
                 serviceAccount = new FileInputStream("src/main/resources/firebase-service-account.json");


### PR DESCRIPTION
Firebase initialization was crashing on Railway because FIREBASE_CREDENTIALS was set to raw JSON, but the code required base64 and threw on decode.