### PR TITLE
Cap JVM heap to container memory limit to prevent OOM-kill restart loop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ FROM eclipse-temurin:17-jre
 WORKDIR /app
 COPY --from=build /app/target/*.jar app.jar
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-jar", "app.jar"]


### PR DESCRIPTION
Railway was OOM-killing the container before Spring Boot finished starting since the JVM sized its heap off host RAM instead of the container's actual memory limit.